### PR TITLE
fix: SatispayResponseException - param type

### DIFF
--- a/src/Exceptions/SatispayResponseException.php
+++ b/src/Exceptions/SatispayResponseException.php
@@ -22,9 +22,9 @@ class SatispayResponseException extends SatispayException {
      * BaseResponseException constructor.
      *
      * @param SatispayResponse $satispayResponse The SatispayResponse object representing the API response.
-     * @param string|null The message shown in the exception.
+     * @param array|string|null The message shown in the exception.
      */
-    public function __construct(SatispayResponse $satispayResponse, string|null $message = null)
+    public function __construct(SatispayResponse $satispayResponse, array|string|null $message = null)
     {
         $this->response = $satispayResponse;
         $this->code = $satispayResponse->getErrorCode();


### PR DESCRIPTION
Hi,
I fixed this exception encored during the checkExceptions call. 

`EmanueleCoppola\Satispay\Exceptions\SatispayResponseException::__construct(): Argument #2 ($message) must be of type ?string, array given, called in /var/www/vhosts/.../vendor/emanuelecoppola/satispay-php-sdk/src/SatispayResponse.php on line 81`

`/var/www/vhosts/.../vendor/emanuelecoppola/satispay-php-sdk/src/SatispayResponse.php:81
/var/www/vhosts/.../vendor/emanuelecoppola/satispay-php-sdk/src/Services/AuthenticationService.php:105
`